### PR TITLE
Fix root node leaking

### DIFF
--- a/AtomicBinding.lua
+++ b/AtomicBinding.lua
@@ -97,6 +97,7 @@ function AtomicBinding.new(tag, manifest, fn)
 			rootNode.children = {}
 			rootNode.connections = {}
 		end
+		rootInstToRootNode[root] = rootNode
 		
 		for alias, rawPath in pairs(manifest) do
 			local parsedPath = parsePath(rawPath)


### PR DESCRIPTION
Seems like `rootInstToRootNode` is never set, and therefore not being cleaned up in `unbindRoot`, this should clean it up!

(Untested, quickly did this through GitHub UI)